### PR TITLE
Test and fix rounding in timezones

### DIFF
--- a/src/BusinessTime.php
+++ b/src/BusinessTime.php
@@ -406,11 +406,22 @@ class BusinessTime extends Carbon
      */
     public function floor(DateInterval $precision = null): self
     {
-        $seconds = Interval::instance($precision ?: $this->precision())
-            ->inSeconds();
+        $precisionSeconds = Interval::instance($precision ?: $this->precision())
+                                    ->inSeconds();
+
+        // Allow for sub-hour timezone differences:
+        // Add the timezone remainder, floor, then take the remainder back off.
+        $timezoneOffset = $this->getTimezone()->getOffset(new Carbon());
+        $timezoneRemainder = $timezoneOffset % 3600;
 
         return $this->copy()->setTimestamp(
-            (int) (floor($this->timestamp / $seconds) * $seconds)
+            (int) (
+                floor(
+                    (
+                        $this->timestamp + $timezoneRemainder
+                    ) / $precisionSeconds
+                ) * $precisionSeconds
+            ) - $timezoneRemainder
         );
     }
 
@@ -425,11 +436,22 @@ class BusinessTime extends Carbon
      */
     public function round(DateInterval $precision = null): self
     {
-        $seconds = Interval::instance($precision ?: $this->precision())
-            ->inSeconds();
+        $precisionSeconds = Interval::instance($precision ?: $this->precision())
+                                    ->inSeconds();
+
+        // Allow for sub-hour timezone differences:
+        // Add the timezone remainder, round, then take the remainder back off.
+        $timezoneOffset = $this->getTimezone()->getOffset(new Carbon());
+        $timezoneRemainder = $timezoneOffset % 3600;
 
         return $this->copy()->setTimestamp(
-            (int) (round($this->timestamp / $seconds) * $seconds)
+            (int) (
+                round(
+                    (
+                        $this->timestamp + $timezoneRemainder
+                    ) / $precisionSeconds
+                ) * $precisionSeconds
+            ) - $timezoneRemainder
         );
     }
 
@@ -448,10 +470,21 @@ class BusinessTime extends Carbon
     public function ceil(DateInterval $precision = null): self
     {
         $seconds = Interval::instance($precision ?: $this->precision())
-            ->inSeconds();
+                           ->inSeconds();
+
+        // Allow for sub-hour timezone differences:
+        // Add the timezone remainder, ceil, then take the remainder back off.
+        $timezoneOffset = $this->getTimezone()->getOffset(new Carbon());
+        $timezoneRemainder = $timezoneOffset % 3600;
 
         return $this->copy()->setTimestamp(
-            (int) (ceil($this->timestamp / $seconds) * $seconds)
+            (int) (
+                ceil(
+                    (
+                        $this->timestamp + $timezoneRemainder
+                    ) / $seconds
+                ) * $seconds
+            ) - $timezoneRemainder
         );
     }
 
@@ -522,8 +555,8 @@ ERR
 
         return $this->setLengthOfBusinessDay(
             $this->copy()
-                ->setTimestamp($typicalDay->startOfDay()->getTimestamp())
-                ->diffBusiness($typicalDay->endOfDay())
+                 ->setTimestamp($typicalDay->startOfDay()->getTimestamp())
+                 ->diffBusiness($typicalDay->endOfDay())
         );
     }
 

--- a/tests/Unit/BusinessTime/LengthOfBusinessDayTest.php
+++ b/tests/Unit/BusinessTime/LengthOfBusinessDayTest.php
@@ -25,12 +25,18 @@ class LengthOfBusinessDayTest extends TestCase
         $time = new BusinessTime();
 
         // Then the length of a business day should be 8 hours.
-        self::assertSame(
-            '8 hours',
-            $time->lengthOfBusinessDay()->forHumans()
+        self::assertEquals(
+            8,
+            $time->lengthOfBusinessDay()->inHours(),
+            'Should be 8 hours',
+            2
         );
-        self::assertEquals(8, $time->lengthOfBusinessDay()->inHours());
-        self::assertEquals(480, $time->lengthOfBusinessDay()->inMinutes());
+        self::assertEquals(
+            480,
+            $time->lengthOfBusinessDay()->inMinutes(),
+            'Should be 480 minutes',
+            2
+        );
     }
 
     /**
@@ -39,11 +45,11 @@ class LengthOfBusinessDayTest extends TestCase
      * @dataProvider lengthOfBusinessDayProvider
      *
      * @param Interval $length
-     * @param string   $expectedDescription
+     * @param int      $expectedSeconds
      */
     public function testSetLengthOfBusinessDay(
         Interval $length,
-        string $expectedDescription
+        int $expectedSeconds
     ) {
         // Given we have a business time;
         $time = new BusinessTime();
@@ -52,9 +58,11 @@ class LengthOfBusinessDayTest extends TestCase
         $time->setLengthOfBusinessDay($length);
 
         // Then the length of the business day should be adjusted.
-        self::assertSame(
-            $expectedDescription,
-            $time->lengthOfBusinessDay()->forHumans()
+        self::assertEquals(
+            $expectedSeconds,
+            $time->lengthOfBusinessDay()->inSeconds(),
+            "Should be ${expectedSeconds}",
+            2
         );
     }
 
@@ -66,12 +74,12 @@ class LengthOfBusinessDayTest extends TestCase
     public function lengthOfBusinessDayProvider(): array
     {
         return [
-            [Interval::hour(), '1 hour'],
-            [Interval::hours(2), '2 hours'],
-            [Interval::hours(6), '6 hours'],
-            [Interval::hours(18), '18 hours'],
-            [Interval::minutes((8 * 60) + 30), '8 hours 30 minutes'],
-            [Interval::minutes((6 * 60) + 59), '6 hours 59 minutes'],
+            [Interval::hour(), 60 * 60],
+            [Interval::hours(2), 2 * 60 * 60],
+            [Interval::hours(6), 6 * 60 * 60],
+            [Interval::hours(18), 18 * 60 * 60],
+            [Interval::minutes((8 * 60) + 30), 8.5 * 60 * 60],
+            [Interval::minutes((6 * 60) + 59), (6 * 60 * 60) + (59 * 60)],
         ];
     }
 
@@ -82,11 +90,11 @@ class LengthOfBusinessDayTest extends TestCase
      * @dataProvider determineLengthOfBusinessDayProvider
      *
      * @param BusinessTimeConstraint $constraint
-     * @param string                 $expectedDescription
+     * @param int                    $expectedSeconds
      */
     public function testDetermineLengthOfBusinessDay(
         BusinessTimeConstraint $constraint,
-        string $expectedDescription
+        int $expectedSeconds
     ) {
         // Given we have a business time with certain constraints;
         $time = new BusinessTime();
@@ -96,9 +104,11 @@ class LengthOfBusinessDayTest extends TestCase
         $time->determineLengthOfBusinessDay();
 
         // Then the determined length of a business day should be as expected.
-        self::assertSame(
-            $expectedDescription,
-            $time->lengthOfBusinessDay()->forHumans()
+        self::assertEquals(
+            $expectedSeconds,
+            $time->lengthOfBusinessDay()->inSeconds(),
+            "Should be {$expectedSeconds}",
+            2
         );
     }
 
@@ -111,32 +121,32 @@ class LengthOfBusinessDayTest extends TestCase
     public function determineLengthOfBusinessDayProvider(): array
     {
         return [
-            [new BetweenHoursOfDay(9, 17), '8 hours'],
-            [new BetweenHoursOfDay(9, 12), '3 hours'],
-            [new BetweenHoursOfDay(8, 18), '10 hours'],
-            [new BetweenHoursOfDay(0, 23), '23 hours'],
-            [new BetweenHoursOfDay(0, 24), '1 day'],
-            [new WeekDays(), '1 day'],
+            [new BetweenHoursOfDay(9, 17), 8 * 60 * 60],
+            [new BetweenHoursOfDay(9, 12), 3 * 60 * 60],
+            [new BetweenHoursOfDay(8, 18), 10 * 60 * 60],
+            [new BetweenHoursOfDay(0, 23), 23 * 60 * 60],
+            [new BetweenHoursOfDay(0, 24), 24 * 60 * 60],
+            [new WeekDays(), 24 * 60 * 60],
             [
                 new All(
                     new WeekDays(),
                     new BetweenHoursOfDay(9, 17)
                 ),
-                '8 hours',
+                8 * 60 * 60,
             ],
             [
                 // Exclude lunch time.
                 (new BetweenHoursOfDay(9, 17))->except(
                     new BetweenHoursOfDay(13, 14)
                 ),
-                '7 hours',
+                7 * 60 * 60,
             ],
             [
                 // Multiple periods.
                 (new BetweenHoursOfDay(8, 10))
                     ->orAlternatively(new BetweenHoursOfDay(12, 14))
                     ->orAlternatively(new BetweenHoursOfDay(16, 18)),
-                '6 hours',
+                6 * 60 * 60,
             ],
         ];
     }

--- a/tests/Unit/BusinessTime/PrecisionTest.php
+++ b/tests/Unit/BusinessTime/PrecisionTest.php
@@ -21,8 +21,12 @@ class PrecisionTest extends TestCase
         $time = new BusinessTime();
 
         // Then the precision should be 1 hour.
-        self::assertSame('1 hour', $time->precision()->forHumans());
-        self::assertSame(1.0, $time->precision()->inHours());
+        self::assertEquals(
+            1.0,
+            $time->precision()->inHours(),
+            'Should be 1 hour',
+            2
+        );
     }
 
     /**
@@ -31,11 +35,11 @@ class PrecisionTest extends TestCase
      * @dataProvider setPrecisionProvider
      *
      * @param DateInterval $precision
-     * @param string       $expectedDescription
+     * @param int          $expectedSeconds
      */
     public function testSetPrecision(
         DateInterval $precision,
-        string $expectedDescription
+        int $expectedSeconds
     ) {
         // Given we have a business time instance;
         $time = new BusinessTime();
@@ -44,7 +48,12 @@ class PrecisionTest extends TestCase
         $time->setPrecision($precision);
 
         // Then the precision should be as expected.
-        self::assertSame($expectedDescription, $time->precision()->forHumans());
+        self::assertEquals(
+            $expectedSeconds,
+            $time->precision()->inSeconds(),
+            "Should be {$expectedSeconds} seconds",
+            2
+        );
     }
 
     /**
@@ -53,10 +62,10 @@ class PrecisionTest extends TestCase
     public function setPrecisionProvider(): array
     {
         return [
-            [Interval::second(), '1 second'],
-            [Interval::minute(), '1 minute'],
-            [Interval::seconds(90), '1 minute 30 seconds'],
-            [Interval::hour(), '1 hour'],
+            [Interval::second(), 1],
+            [Interval::minute(), 60],
+            [Interval::seconds(90), 90],
+            [Interval::hour(), 3600],
         ];
     }
 

--- a/tests/Unit/BusinessTime/TimeZoneTest.php
+++ b/tests/Unit/BusinessTime/TimeZoneTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace BusinessTime\Tests\Unit\BusinessTime;
+
+use BusinessTime\Interval;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use BusinessTime\BusinessTime;
+
+/**
+ * Test that business time calculations work correctly in different timezones.
+ */
+class TimeZoneTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        // Reset the default timezone.
+        date_default_timezone_set('UTC');
+        Carbon::setTestNow(Carbon::now()->setTimezone('UTC'));
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     *
+     * @param string $timezone
+     */
+    public function testFloorToHourInTimezone(string $timezone)
+    {
+        // Given we are in a particular timezone.
+        date_default_timezone_set($timezone);
+        Carbon::setTestNow(Carbon::now()->setTimezone($timezone));
+
+        // And we have a business time instance for a specific time;
+        $businessTime = new BusinessTime(
+            "2018-05-23 17:48 {$timezone}"
+        );
+        $businessTime = $businessTime->setTimezone($timezone);
+
+        // When we floor it to the nearest hour.
+        $floored = $businessTime->floor(Interval::hour());
+
+        // Then we should get the expected floored time.
+        self::assertSame(
+            "2018-05-23 17:00 {$timezone}",
+            $floored->format('Y-m-d H:i e'),
+            <<<MSG
+2018-05-23 17:48 {$timezone}
+floored to the hour should be
+2018-05-23 17:00 {$timezone};
+got
+{$floored->format('Y-m-d H:i e')}.
+MSG
+        );
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     *
+     * @param string $timezone
+     */
+    public function testRoundDownToHourInTimezone(string $timezone)
+    {
+        // Given we are in a particular timezone.
+        date_default_timezone_set($timezone);
+        Carbon::setTestNow(Carbon::now()->setTimezone($timezone));
+
+        // And we have a business time instance for a specific time;
+        $businessTime = new BusinessTime(
+            "2018-05-23 17:23 {$timezone}"
+        );
+        $businessTime = $businessTime->setTimezone($timezone);
+
+        // When we round it to the nearest hour.
+        $floored = $businessTime->round(Interval::hour());
+
+        // Then we should get the expected rounded time.
+        self::assertSame(
+            "2018-05-23 17:00 {$timezone}",
+            $floored->format('Y-m-d H:i e'),
+            <<<MSG
+2018-05-23 17:23 {$timezone}
+rounded to the hour should be
+2018-05-23 17:00 {$timezone};
+got
+{$floored->format('Y-m-d H:i e')}.
+MSG
+        );
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     *
+     * @param string $timezone
+     */
+    public function testRoundUpToHourInTimezone(string $timezone)
+    {
+        // Given we are in a particular timezone.
+        date_default_timezone_set($timezone);
+        Carbon::setTestNow(Carbon::now()->setTimezone($timezone));
+
+        // And we have a business time instance for a specific time;
+        $businessTime = new BusinessTime(
+            "2018-05-23 17:32 {$timezone}"
+        );
+        $businessTime = $businessTime->setTimezone($timezone);
+
+        // When we round it to the nearest hour.
+        $floored = $businessTime->round(Interval::hour());
+
+        // Then we should get the expected rounded time.
+        self::assertSame(
+            "2018-05-23 18:00 {$timezone}",
+            $floored->format('Y-m-d H:i e'),
+            <<<MSG
+2018-05-23 17:32 {$timezone}
+floored to the hour should be
+2018-05-23 18:00 {$timezone};
+got
+{$floored->format('Y-m-d H:i e')}.
+MSG
+        );
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     *
+     * @param string $timezone
+     */
+    public function testCeilDownToHourInTimezone(string $timezone)
+    {
+        // Given we are in a particular timezone.
+        date_default_timezone_set($timezone);
+        Carbon::setTestNow(Carbon::now()->setTimezone($timezone));
+
+        // And we have a business time instance for a specific time;
+        $businessTime = new BusinessTime(
+            "2018-05-23 17:23 {$timezone}"
+        );
+        $businessTime = $businessTime->setTimezone($timezone);
+
+        // When we ceil it to the nearest hour.
+        $floored = $businessTime->ceil(Interval::hour());
+
+        // Then we should get the expected rounded time.
+        self::assertSame(
+            "2018-05-23 18:00 {$timezone}",
+            $floored->format('Y-m-d H:i e'),
+            <<<MSG
+2018-05-23 17:23 {$timezone}
+ceiled to the hour should be
+2018-05-23 18:00 {$timezone};
+got
+{$floored->format('Y-m-d H:i e')}.
+MSG
+        );
+    }
+
+    /**
+     * @return array[]
+     */
+    public function timezoneProvider(): array
+    {
+        return [
+            ['Africa/Bangui'],
+            ['Africa/Kinshasa'],
+            ['Africa/Windhoek'],
+            ['America/Cayenne'],
+            ['America/Guatemala'],
+            ['America/New_York'],
+            ['America/Toronto'],
+            ['Antarctica/Casey'],
+            ['Antarctica/Troll'],
+            ['Antarctica/Vostok'],
+            ['Arctic/Longyearbyen'],
+            ['Asia/Bishkek'],
+            ['Asia/Kathmandu'],
+            ['Asia/Rangoon'],
+            ['Asia/Seoul'],
+            ['Asia/Shanghai'],
+            ['Asia/Tehran'],
+            ['Asia/Tokyo'],
+            ['Atlantic/Reykjavik'],
+            ['Australia/Adelaide'],
+            ['Australia/Sydney'],
+            ['Europe/Amsterdam'],
+            ['Europe/London'],
+            ['Europe/Zurich'],
+            ['Indian/Antananarivo'],
+            ['Indian/Reunion'],
+            ['Pacific/Auckland'],
+            ['Pacific/Kwajalein'],
+            ['Pacific/Majuro'],
+            ['Pacific/Saipan'],
+            ['Pacific/Tongatapu'],
+            ['UTC'],
+        ];
+    }
+}


### PR DESCRIPTION
 - Add tests to cover various timezones.
 - Fix issue with sub-hour timezone differences where the time is rounded to the nearest UTC hour, and not the nearest local hour.