### PR TITLE
Improve negative interval handling 

### DIFF
--- a/src/BusinessTime.php
+++ b/src/BusinessTime.php
@@ -369,9 +369,16 @@ class BusinessTime extends Carbon
         DateTimeInterface $time = null,
         bool $absolute = true
     ): Interval {
+        $diffInBusinessTime = $this->diffInBusinessTime($time, $absolute);
+        // Allow for weird behaviour of DateInterval with negatives.
+        if ($diffInBusinessTime < 0 && !$absolute) {
+            /** @var Interval $interval */
+            $interval = Interval::seconds(0);
+            $interval->seconds = $diffInBusinessTime * $this->precision()->inSeconds();
+            return $interval;
+        }
         return Interval::seconds(
-            $this->diffInBusinessTime($time, $absolute)
-            * $this->precision()->inSeconds()
+            abs($diffInBusinessTime) * $this->precision()->inSeconds()
         );
     }
 

--- a/tests/Unit/BusinessTime/DiffBusinessTest.php
+++ b/tests/Unit/BusinessTime/DiffBusinessTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BusinessTime\Tests\Unit\BusinessTime;
+
+use BusinessTime\BusinessTime;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the BusinessTime::diffBusiness() method.
+ */
+class DiffBusinessTest extends TestCase
+{
+    /**
+     * Should be able to handle start date being after end date.
+     */
+    public function testStartAfterEnd()
+    {
+        // Given we have a business time as a start;
+        $start = new BusinessTime('Monday 11am');
+
+        // And an end time that is before that;
+        $end = new BusinessTime('Monday 10am');
+
+        // When we get the difference in business time;
+        $diff = $start->diffBusiness($end);
+
+        // Then it should still be correct.
+        self::assertEquals(60, $diff->inMinutes());
+    }
+}

--- a/tests/Unit/BusinessTime/DiffBusinessTest.php
+++ b/tests/Unit/BusinessTime/DiffBusinessTest.php
@@ -13,7 +13,7 @@ class DiffBusinessTest extends TestCase
     /**
      * Should be able to handle start date being after end date.
      */
-    public function testStartAfterEnd()
+    public function testStartAfterEndAbsolute()
     {
         // Given we have a business time as a start;
         $start = new BusinessTime('Monday 11am');
@@ -21,10 +21,30 @@ class DiffBusinessTest extends TestCase
         // And an end time that is before that;
         $end = new BusinessTime('Monday 10am');
 
-        // When we get the difference in business time;
+        // When we get the absolute difference in business time;
         $diff = $start->diffBusiness($end);
 
         // Then it should still be correct.
+        self::assertEquals(60, $diff->inMinutes());
+    }
+
+    /**
+     * Should be able to handle start date being after end date.
+     */
+    public function testStartAfterEndNonAbsolute()
+    {
+        // Given we have a business time as a start;
+        $start = new BusinessTime('Monday 11am');
+
+        // And an end time that is before that;
+        $end = new BusinessTime('Monday 10am');
+
+        // When we get the non-absolute difference in business time;
+        $diff = $start->diffBusiness($end, false);
+
+        // Then it should still be correct (note weirdness with how DateInterval
+        // handles negatives and units).
+        self::assertEquals(-3600, $diff->seconds);
         self::assertEquals(60, $diff->inMinutes());
     }
 }

--- a/tests/Unit/Interval/IntervalTest.php
+++ b/tests/Unit/Interval/IntervalTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BusinessTime\Tests\Unit\Interval;
+
+use BusinessTime\Interval;
+use PHPUnit\Framework\TestCase;
+
+class IntervalTest extends TestCase
+{
+    public function testPositiveInterval()
+    {
+        // Given we have a positive number of seconds;
+        $seconds = 3600;
+
+        // When we construct and interval with it;
+        /** @var Interval $interval */
+        $interval = Interval::seconds($seconds);
+
+        // Then it should be correct.
+        self::assertEquals(60, $interval->inMinutes());
+    }
+
+    public function testNegativeInterval()
+    {
+        // Given we have a negative number of seconds;
+        $seconds = -3600;
+
+        // When we construct and interval with it;
+        /** @var Interval $interval */
+        $interval = Interval::seconds(0);
+        $interval->seconds = $seconds;
+        $interval->invert = 1;
+
+        // Then it should be correct.
+        self::assertEquals(-3600, $interval->seconds);
+        self::assertEquals(60, $interval->inMinutes());
+    }
+}


### PR DESCRIPTION
`DateInterval` seems to handle negatives quite weirdly. E.g. the `CarbonInterval::inMinutes()` method always returns positive. This does make sense in one way, as an interval is in some sense always a positive number.

This PR makes it work a little better than previously, as it was defaulting to 0 for negative intervals.

https://www.php.net/manual/en/class.dateinterval.php