### PR TITLE
Limit business time iterations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 test: src tests vendor/autoload.php
 	./vendor/phpmd/phpmd/src/bin/phpmd src text \
-		controversial,design,naming,unusedcode
+		controversial,naming,unusedcode
 	./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PSR2 --colors src
 	./vendor/phpunit/phpunit/phpunit
 
@@ -13,7 +13,7 @@ coverage: src tests vendor/autoload.php
 	mkdir -p build
 	rm -rf build/*
 	./vendor/phpmd/phpmd/src/bin/phpmd src text \
-			controversial,design,naming,unusedcode \
+			controversial,naming,unusedcode \
 			--reportfile ./build/phpmd.xml
 	./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=PSR2 --colors src \
 		--report-file=./build/phpcs.xml

--- a/src/BusinessTime.php
+++ b/src/BusinessTime.php
@@ -29,6 +29,9 @@ class BusinessTime extends Carbon
     /** @var Interval */
     private $precision;
 
+    /** @var int */
+    private $iterationLimit = LimitedIterator::DEFAULT_ITERATION_LIMIT;
+
     /**
      * Is it business time?
      *
@@ -54,11 +57,15 @@ class BusinessTime extends Carbon
         // Iterate from the beginning of the day until we hit business time.
         $time = $this->copy()->startOfDay();
         $end = $this->copy()->endOfDay();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($time->lt($end)) {
             if ($time->isBusinessTime()) {
                 return true;
             }
             $time = $time->add($this->precision());
+
+            $limit->next();
         }
 
         return false;
@@ -68,8 +75,6 @@ class BusinessTime extends Carbon
      * Get the date time after adding one whole business day.
      *
      * @see AddBusinessDaysTest
-     *
-     * @throws \InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -87,8 +92,6 @@ class BusinessTime extends Carbon
      * @see AddBusinessDaysTest
      *
      * @param float $businessDaysToAdd
-     *
-     * @throws \InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -113,12 +116,15 @@ class BusinessTime extends Carbon
         $decrement = $this->precision()->inDays()
             / $this->lengthOfBusinessDay()->inDays();
 
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($businessDaysToAdd > 0) {
             /* @scrutinizer ignore-call */
             if ($next->isBusinessTime()) {
                 $businessDaysToAdd -= $decrement;
             }
             $next = $next->add($this->precision());
+
+            $limit->next();
         }
 
         // Ensure we always end on a business day.
@@ -134,8 +140,6 @@ class BusinessTime extends Carbon
      *
      * @see SubBusinessDaysTest
      *
-     * @throws \InvalidArgumentException
-     *
      * @return BusinessTime
      */
     public function subBusinessDay(): self
@@ -149,8 +153,6 @@ class BusinessTime extends Carbon
      * @see SubBusinessDaysTest
      *
      * @param float $businessDaysToSub
-     *
-     * @throws \InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -174,11 +176,14 @@ class BusinessTime extends Carbon
         $decrement = $this->precision()->inDays()
             / $this->lengthOfBusinessDay()->inDays();
 
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($businessDaysToSub > 0) {
             $prev = $prev->sub($this->precision());
             if ($prev->isBusinessTime()) {
                 $businessDaysToSub -= $decrement;
             }
+
+            $limit->next();
         }
 
         // Ensure we always end on a business day.
@@ -194,8 +199,6 @@ class BusinessTime extends Carbon
      *
      * @see AddBusinessHoursTest
      *
-     * @throws \InvalidArgumentException
-     *
      * @return BusinessTime
      */
     public function addBusinessHour(): self
@@ -210,8 +213,6 @@ class BusinessTime extends Carbon
      *
      * @see AddBusinessHoursTest
      *
-     * @throws \InvalidArgumentException
-     *
      * @return BusinessTime
      */
     public function addBusinessHours(float $businessHoursToAdd): self
@@ -223,12 +224,16 @@ class BusinessTime extends Carbon
         /** @var BusinessTime $next */
         $next = $this->copy();
         $decrement = $this->precision()->inHours();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($businessHoursToAdd > 0) {
             /* @scrutinizer ignore-call */
             if ($next->isBusinessTime()) {
                 $businessHoursToAdd -= $decrement;
             }
             $next = $next->add($this->precision());
+
+            $limit->next();
         }
 
         return $next;
@@ -238,8 +243,6 @@ class BusinessTime extends Carbon
      * Get the date time after subtracting one business hour.
      *
      * @see SubBusinessHoursTest
-     *
-     * @throws \InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -255,8 +258,6 @@ class BusinessTime extends Carbon
      *
      * @param float $businessHoursToSub
      *
-     * @throws \InvalidArgumentException
-     *
      * @return BusinessTime
      */
     public function subBusinessHours(float $businessHoursToSub): self
@@ -267,11 +268,15 @@ class BusinessTime extends Carbon
 
         $prev = $this->copy();
         $decrement = $this->precision()->inHours();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($businessHoursToSub > 0) {
             $prev = $prev->sub($this->precision());
             if ($prev->isBusinessTime()) {
                 $businessHoursToSub -= $decrement;
             }
+
+            $limit->next();
         }
 
         return $prev;
@@ -284,8 +289,6 @@ class BusinessTime extends Carbon
      *
      * @param DateTimeInterface $time
      * @param bool              $absolute
-     *
-     * @throws \InvalidArgumentException
      *
      * @return int
      */
@@ -321,8 +324,6 @@ class BusinessTime extends Carbon
      *
      * @param DateTimeInterface $time
      * @param bool              $absolute
-     *
-     * @throws InvalidArgumentException
      *
      * @return float
      */
@@ -401,8 +402,12 @@ class BusinessTime extends Carbon
     {
         // Iterate from the beginning of the day until we hit business time.
         $start = $this->copy()->startOfDay();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while (!$start->isBusinessTime()) {
             $start = $start->add($this->precision());
+
+            $limit->next();
         }
 
         return $start;
@@ -417,8 +422,12 @@ class BusinessTime extends Carbon
     {
         // Iterate back from the end of the day until we hit business time.
         $end = $this->copy()->endOfDay();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while (!$end->isBusinessTime()) {
             $end = $end->sub($this->precision());
+
+            $limit->next();
         }
 
         // Add a second because we've iterated from 23:59:59.
@@ -523,8 +532,6 @@ class BusinessTime extends Carbon
     }
 
     /**
-     * @throws InvalidArgumentException
-     *
      * @return Interval
      */
     public function lengthOfBusinessDay(): Interval
@@ -540,8 +547,6 @@ class BusinessTime extends Carbon
 
     /**
      * @param DateInterval $length
-     *
-     * @throws InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -570,8 +575,6 @@ ERR
 
     /**
      * @param DateTime $typicalDay
-     *
-     * @throws InvalidArgumentException
      *
      * @return BusinessTime
      */
@@ -656,8 +659,6 @@ ERR
      *
      * @param DateInterval $precision
      *
-     * @throws InvalidArgumentException
-     *
      * @return BusinessTime
      */
     public function setPrecision(DateInterval $precision): self
@@ -690,6 +691,21 @@ ERR
         return (new static())
             ->setTimezone($dti->getTimezone())
             ->setTimestamp($dti->getTimestamp());
+    }
+
+    /**
+     * Set the maximum number of loop iterations when doing business time
+     * operations.
+     *
+     * @param int $iterationLimit
+     *
+     * @return BusinessTime
+     */
+    public function setIterationLimit(int $iterationLimit): self
+    {
+        $this->iterationLimit = $iterationLimit;
+
+        return $this;
     }
 
     /**
@@ -729,12 +745,16 @@ ERR
         /** @var BusinessTime $next */
         /** @scrutinizer ignore-call */
         $next = $start->copy();
+
+        $limit = new LimitedIterator($this->iterationLimit);
         while ($next < $end) {
             /* @scrutinizer ignore-call */
             if ($next->isBusinessTime()) {
                 $diff++;
             }
             $next = $next->add($this->precision());
+
+            $limit->next();
         }
 
         return $diff * $sign;

--- a/src/BusinessTimeFactory.php
+++ b/src/BusinessTimeFactory.php
@@ -17,6 +17,9 @@ class BusinessTimeFactory
     /** @var Interval */
     private $precision;
 
+    /** @var int */
+    private $iterationLimit = LimitedIterator::DEFAULT_ITERATION_LIMIT;
+
     /**
      * @param Interval|null          $precision
      * @param BusinessTimeConstraint ...$constraints
@@ -42,6 +45,7 @@ class BusinessTimeFactory
         $businessTime = new BusinessTime($time);
         $businessTime->setBusinessTimeConstraints(...$this->constraints);
         $businessTime->setPrecision($this->precision);
+        $businessTime->setIterationLimit($this->iterationLimit);
 
         return $businessTime;
     }
@@ -77,6 +81,18 @@ class BusinessTimeFactory
     public function setPrecision(Interval $precision): self
     {
         $this->precision = $precision;
+
+        return $this;
+    }
+
+    /**
+     * @param int $iterationLimit
+     *
+     * @return BusinessTimeFactory
+     */
+    public function setIterationLimit(int $iterationLimit): self
+    {
+        $this->iterationLimit = $iterationLimit;
 
         return $this;
     }

--- a/src/LimitedIterator.php
+++ b/src/LimitedIterator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace BusinessTime;
+
+use Iterator;
+use LengthException;
+
+/**
+ * Iterates until a limit is reached, then throws an exception.
+ */
+class LimitedIterator implements Iterator
+{
+    const DEFAULT_ITERATION_LIMIT = 10000;
+
+    /** @var int */
+    private $iterations = 0;
+
+    /** @var int */
+    private $iterationLimit;
+
+    public function __construct(int $iterationLimit = self::DEFAULT_ITERATION_LIMIT)
+    {
+        $this->iterationLimit = $iterationLimit;
+    }
+
+    /**
+     * Return the current element
+     *
+     * @link  https://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     * @since 5.0.0
+     */
+    public function current()
+    {
+        return $this->iterations;
+    }
+
+    /**
+     * Move forward to next element
+     *
+     * @link  https://php.net/manual/en/iterator.next.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function next()
+    {
+        $this->iterations++;
+        if ($this->iterations > $this->iterationLimit) {
+            throw new LengthException(
+                "Iteration limit of {$this->iterationLimit} reached."
+            );
+        }
+    }
+
+    /**
+     * Return the key of the current element
+     *
+     * @link  https://php.net/manual/en/iterator.key.php
+     * @return mixed scalar on success, or null on failure.
+     * @since 5.0.0
+     */
+    public function key()
+    {
+        return $this->iterations;
+    }
+
+    /**
+     * Checks if current position is valid
+     *
+     * @link  https://php.net/manual/en/iterator.valid.php
+     * @return boolean The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
+     * @since 5.0.0
+     */
+    public function valid()
+    {
+        return $this->iterations <= $this->iterationLimit;
+    }
+
+    /**
+     * Rewind the Iterator to the first element
+     *
+     * @link  https://php.net/manual/en/iterator.rewind.php
+     * @return void Any returned value is ignored.
+     * @since 5.0.0
+     */
+    public function rewind()
+    {
+        $this->iterations = 0;
+    }
+}

--- a/tests/Unit/BusinessTime/IterationLimitTest.php
+++ b/tests/Unit/BusinessTime/IterationLimitTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BusinessTime\Tests\Unit\BusinessTime;
+
+use BusinessTime\BusinessTime;
+use LengthException;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class IterationLimitTest extends TestCase
+{
+    public function testThrowsOnIterationLimit()
+    {
+        // Given we have a business time;
+        $businessTime = new BusinessTime();
+
+        // And we set the iteration limit to be very low;
+        $businessTime->setIterationLimit(3);
+
+        // When we try to add several business hours;
+        $error = null;
+        try {
+            $businessTime->addBusinessHours(36);
+        } catch (Throwable $e) {
+            $error = $e;
+        }
+
+        // Then an error should be thrown due to the iteration limit.
+        self::assertInstanceOf(LengthException::class, $error);
+        self::assertEquals($error->getMessage(), 'Iteration limit of 3 reached.');
+    }
+}

--- a/tests/Unit/BusinessTime/IterationLimitTest.php
+++ b/tests/Unit/BusinessTime/IterationLimitTest.php
@@ -3,6 +3,7 @@
 namespace BusinessTime\Tests\Unit\BusinessTime;
 
 use BusinessTime\BusinessTime;
+use BusinessTime\LimitedIterator;
 use LengthException;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -29,5 +30,35 @@ class IterationLimitTest extends TestCase
         // Then an error should be thrown due to the iteration limit.
         self::assertInstanceOf(LengthException::class, $error);
         self::assertEquals($error->getMessage(), 'Iteration limit of 3 reached.');
+    }
+
+
+    public function testLimitedIterator()
+    {
+        // Given we have a limited iterator;
+        $limit = new LimitedIterator(5);
+
+        // When we iterate within the limit;
+        while ($limit->current() < 5) {
+            $limit->next();
+        }
+
+        // Then the iterator should not throw;
+        self::assertEquals(5, $limit->key());
+
+        // But when we exceed the limit;
+        $limit->rewind();
+        $error = null;
+        try {
+            for ($i = 0; $i < 6; $i++) {
+                $limit->next();
+            }
+        } catch (Throwable $e) {
+            $error = $e;
+        }
+
+        // Then an exception should be thrown.
+        self::assertInstanceOf(LengthException::class, $error);
+        self::assertEquals($error->getMessage(), 'Iteration limit of 5 reached.');
     }
 }

--- a/tests/Unit/BusinessTime/IterationLimitTest.php
+++ b/tests/Unit/BusinessTime/IterationLimitTest.php
@@ -45,6 +45,7 @@ class IterationLimitTest extends TestCase
 
         // Then the iterator should not throw;
         self::assertEquals(5, $limit->key());
+        self::assertTrue($limit->valid());
 
         // But when we exceed the limit;
         $limit->rewind();
@@ -60,5 +61,6 @@ class IterationLimitTest extends TestCase
         // Then an exception should be thrown.
         self::assertInstanceOf(LengthException::class, $error);
         self::assertEquals($error->getMessage(), 'Iteration limit of 5 reached.');
+        self::assertFalse($limit->valid());
     }
 }

--- a/tests/Unit/BusinessTimeFactory/BusinessTimeFactoryTest.php
+++ b/tests/Unit/BusinessTimeFactory/BusinessTimeFactoryTest.php
@@ -22,6 +22,7 @@ class BusinessTimeFactoryTest extends TestCase
         $factory = new BusinessTimeFactory();
         $factory->setConstraints(new DaysOfWeek('Tuesday'));
         $factory->setPrecision(Interval::minutes(30));
+        $factory->setIterationLimit(42);
 
         // When we use it to make a business time instance;
         $businessTime = $factory->make('Wednesday 13:30');


### PR DESCRIPTION
Limit iterations in the BusinessTime class to avoid infinite loops due to bad or unusual business time constraints. The limit can be configured via the BusinessTime class and the BusinessTimeFactoryClass (default is 10000).

https://github.com/hughgrigg/php-business-time/issues/53